### PR TITLE
feat(iOS): Add support for custom Mapbox style via mapboxMapStyle

### DIFF
--- a/ios/MapsIndoorsViewManager.swift
+++ b/ios/MapsIndoorsViewManager.swift
@@ -179,6 +179,14 @@ class MapBoxView: RCMapView {
         if let useMapsIndoorsStyle = config["useDefaultMapsIndoorsStyle"] as? Bool {
             mapConfig.useMapsIndoorsStyle(value: useMapsIndoorsStyle)
         }
+        if let style = config["mapboxMapStyle"] as? String, !style.isEmpty {
+            DispatchQueue.main.async { [mapboxView] in
+                if let uri = StyleURI(rawValue: style) {
+                    mapboxView.mapboxMap.mapStyle = MapStyle(uri: uri)
+                }
+            }
+        }
+
         return mapConfig
     }
 }


### PR DESCRIPTION
This PR adds support for passing a custom Mapbox style URI through the mapboxMapStyle configuration prop on iOS.
This brings iOS to feature parity with Android and allows React Native developers to dynamically set the Mapbox map style from JavaScript.

Currently, the iOS implementation of MapsIndoorsViewManager does not read the mapboxMapStyle value sent from React Native. As a result, developers cannot override the default Mapbox style when rendering indoor maps on iOS.

Android already supports this, so this PR ensures consistency between platforms.