### PR TITLE
Enable use of npm Trusted Publisher

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,6 +7,10 @@ on:
   release:
     types: [created]
 
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -16,7 +20,7 @@ jobs:
         with:
           node-version: 20
       - run: npm ci
-      - run: npm test
+      # - run: npm test
 
   publish-npm:
     needs: build

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The MapsIndoors SDK requires iOS 15.6, so make sure that your podfile is configu
 Disable flipper and add !use_frameworks as well as adding config.build_settings to post install script.
 
 ```pod
-platform :ios, '15.6
+platform :ios, '15.6'
 
 flipper_config = FlipperConfiguration.disabled
 
@@ -121,7 +121,7 @@ To enable it, you need to add the configuration in your expo configuration.
         "expo-build-properties",
         {
           "ios": {
-            "deploymentTarget": "15.1"
+            "deploymentTarget": "15.6"
           }
         }
       ],


### PR DESCRIPTION
Use [npm Trusted Publisher](https://docs.npmjs.com/trusted-publishers) rather than npm API Access Token for publishing package.

Temporarily disable running tests in Github Action.