### PR TITLE
ci: bump checkout/setup-node actions to v5 and Node to 22

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,10 +15,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
       - run: npm ci
       # - run: npm test
 
@@ -26,12 +26,12 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'recursive'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm publish


### PR DESCRIPTION
`actions/checkout@v4` and `actions/setup-node@v4` both ran on Node.js 20 internally, and as of June 16, 2026 GitHub now forces Node.js 24 by default — so v4 of these actions was broken. This bump both to `@v5` (which runs on Node.js 24) and also update the project's `node-version` from 20 to 22 (current LTS, since Node.js 20 itself is being removed from runners in September 2026).