### PR TITLE
ci: publish npm package with public access

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -34,6 +34,6 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org/
       - run: npm ci
-      - run: npm publish
+      - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
npm treats scoped packages (`@org/name`) as private by default, so npm publish without `--access public` attempts to publish as a restricted (paid) package and gets a 404 from the public registry. `--access public` explicitly opts into the free public registry for scoped packages.
